### PR TITLE
Playht experimentation

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,11 +3,13 @@ from services.google_ai_service import GoogleAIService
 from services.open_ai_service import OpenAIService
 from services.huggingface_ai_service import HuggingFaceAIService
 from services.mock_ai_service import MockAIService
+from services.playht_ai_service import PlayHTAIService
 
 services = {
     "azure": AzureAIService,
     "google": GoogleAIService,
     "openai": OpenAIService,
     "huggingface": HuggingFaceAIService,
-    "mock": MockAIService
+    "mock": MockAIService,
+    "playht": PlayHTAIService,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ flask-cors
 transformers
 sentencepiece
 algoliasearch
+pyht

--- a/scenes/start_listening_scene.py
+++ b/scenes/start_listening_scene.py
@@ -15,16 +15,16 @@ class StartListeningScene(Scene):
 			self.ai_complete_sound = audio_file.readframes(-1)
 
 		super().__init__(**kwargs)
-		
+
 	def prepare(self):
 		print("📣 StartListeningScene prepare")
 		# don't need threads here because image
 		# is effectively instant
 		self.scene_data['image'] = self.grandma_listening
-		self.scene_data['audio'] = self.ai_complete_sound
+		self.scene_data['audio'] = [self.ai_complete_sound]
 		print("📣 StartListeningScene prepare complete")
-		
-	
+
+
 	def perform(self):
 		print("📣 StartListeningScene perform")
 		self.orchestrator.start_listening()

--- a/scenes/stop_listening_scene.py
+++ b/scenes/stop_listening_scene.py
@@ -13,16 +13,16 @@ class StopListeningScene(Scene):
 			# Get audio data as a bytestream
 			self.human_complete_sound = audio_file.readframes(-1)
 		super().__init__(**kwargs)
-		
+
 	def prepare(self):
 		print("🤫 StopListeningScene prepare")
 		# don't need threads here because image
 		# is effectively instant
 		self.scene_data['image'] = self.grandma_writing
-		self.scene_data['audio'] = self.human_complete_sound
+		self.scene_data['audio'] = [self.human_complete_sound]
 		print("🤫 StopListeningScene prepare complete")
-		
-	
+
+
 	def perform(self):
 		print("🤫 StopListeningScene perform")
 		self.orchestrator.stop_listening()

--- a/services/azure_ai_service.py
+++ b/services/azure_ai_service.py
@@ -34,7 +34,8 @@ class AzureAIService(AIService):
         print("⌨️ got azure tts result")
         if result.reason == ResultReason.SynthesizingAudioCompleted:
             print("⌨️ returning result")
-            yield result.audio_data
+            # azure always sends a 44-byte header. Strip it off.
+            yield result.audio_data[44:]
         elif result.reason == ResultReason.Canceled:
             cancellation_details = result.cancellation_details
             print("Speech synthesis canceled: {}".format(cancellation_details.reason))

--- a/services/azure_ai_service.py
+++ b/services/azure_ai_service.py
@@ -34,7 +34,7 @@ class AzureAIService(AIService):
         print("⌨️ got azure tts result")
         if result.reason == ResultReason.SynthesizingAudioCompleted:
             print("⌨️ returning result")
-            return result.audio_data
+            yield result.audio_data
         elif result.reason == ResultReason.Canceled:
             cancellation_details = result.cancellation_details
             print("Speech synthesis canceled: {}".format(cancellation_details.reason))

--- a/services/playht_ai_service.py
+++ b/services/playht_ai_service.py
@@ -1,0 +1,52 @@
+import io
+import os
+import struct
+from pyht import Client
+from dotenv import load_dotenv
+from pyht.client import TTSOptions
+from pyht.protos.api_pb2 import Format
+
+from services.ai_service import AIService
+
+class PlayHTAIService(AIService):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.speech_key = os.getenv("PLAY_HT_KEY") or ''
+        self.user_id = os.getenv("PLAY_HT_USER_ID") or ''
+
+        self.client = Client(
+            user_id=self.user_id,
+            api_key=self.speech_key,
+        )
+        self.options = TTSOptions(
+            voice="s3://voice-cloning-zero-shot/820da3d2-3a3b-42e7-844d-e68db835a206/sarah/manifest.json",
+            sample_rate=16000,
+            quality="higher",
+            format=Format.FORMAT_WAV
+        )
+
+    def run_tts(self, sentence):
+        b = bytearray()
+        in_header = True
+        for chunk in self.client.tts(sentence, self.options):
+            # skip the RIFF header.
+            if in_header:
+                b.extend(chunk)
+                if len(b) <= 36:
+                    continue
+                else:
+                    fh = io.BytesIO(b)
+                    fh.seek(36)
+                    (data, size) = struct.unpack('<4sI', fh.read(8))
+                    print(f"first attempt: data: {data}, size: {hex(size)}, position: {fh.tell()}")
+                    while data != b'data':
+                        fh.read(size)
+                        (data, size) = struct.unpack('<4sI', fh.read(8))
+                        print(f"subsequent data: {data}, size: {hex(size)}, position: {fh.tell()}, data != data: {data != b'data'}")
+                    print("position: ", fh.tell())
+                    in_header = False
+            else:
+                if len(chunk):
+                    yield chunk
+


### PR DESCRIPTION
This PR allows play.ht as a source for TTS. play.ht sounds a *lot* better but introduced some complication, because its API returns a generator rather than a complete WAV file, and the WAV header it returns isn't a fixed length the way Azure's is. AFAICT the entire header is always returned in the first chunk, so this code might be more complicated than necessary, but it seemed right to make this robust-enough.

The complication with chunking is we need to align the chunks we send to the microphone on 10ms boundaries, but the chunks we get from play.ht are 4KB each. So I had to do a little extra logic for that to work. I also noticed that sometimes the very last chunk was getting cut off from the next scene, so I added a sleep() after speaking the last chunk. This is sort of a hack but seems to work.